### PR TITLE
Reproducing the `mode` bug

### DIFF
--- a/src/app/show-the-mode/show-the-mode.component.html
+++ b/src/app/show-the-mode/show-the-mode.component.html
@@ -1,3 +1,3 @@
-<p>
-  {{mode}}
-</p>
+<ion-badge>
+  {{ mode }}
+</ion-badge>

--- a/src/app/show-the-mode/show-the-mode.module.ts
+++ b/src/app/show-the-mode/show-the-mode.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { IonicModule } from "@ionic/angular";
 
 import { ShowTheModeComponent } from './show-the-mode.component';
 
@@ -7,7 +8,8 @@ import { ShowTheModeComponent } from './show-the-mode.component';
   declarations: [ShowTheModeComponent],
   exports: [ShowTheModeComponent],
   imports: [
-    CommonModule
+    CommonModule,
+    IonicModule
   ]
 })
 export class ShowTheModeModule { }


### PR DESCRIPTION
Apparently the error occurs when having a custom component with a `mode` property, that wraps an Ionic component:
![image](https://user-images.githubusercontent.com/9556693/77063162-8481a800-69dd-11ea-99b5-d8dac0206591.png)
